### PR TITLE
feat: add S3 artifact transfer concurrency options

### DIFF
--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2585,13 +2585,16 @@ type S3Bucket struct {
 	// CASecret specifies the secret that contains the CA, used to verify the TLS connection
 	CASecret *apiv1.SecretKeySelector `json:"caSecret,omitempty" protobuf:"bytes,11,opt,name=caSecret"`
 
-	// ParallelTransfers controls the maximum number of concurrent upload or download operations
+	// ParallelTransfers controls the maximum number of concurrent upload or download operations.
+	// Defaults to 1 and capped at 32.
 	ParallelTransfers *int32 `json:"parallelTransfers,omitempty" protobuf:"varint,13,opt,name=parallelTransfers"`
 
-	// MultipartPartSize controls the size of each part in multipart uploads in bytes
+	// MultipartPartSize controls the size of each part in multipart uploads in bytes.
+	// Defaults to 5 MiB.
 	MultipartPartSize *int64 `json:"multipartPartSize,omitempty" protobuf:"varint,14,opt,name=multipartPartSize"`
 
-	// MultipartConcurrency controls the number of concurrent multipart upload parts
+	// MultipartConcurrency controls the number of concurrent multipart upload parts.
+	// Defaults to 4.
 	MultipartConcurrency *int32 `json:"multipartConcurrency,omitempty" protobuf:"varint,15,opt,name=multipartConcurrency"`
 }
 

--- a/pkg/apis/workflow/v1alpha1/workflow_types.go
+++ b/pkg/apis/workflow/v1alpha1/workflow_types.go
@@ -2584,6 +2584,15 @@ type S3Bucket struct {
 
 	// CASecret specifies the secret that contains the CA, used to verify the TLS connection
 	CASecret *apiv1.SecretKeySelector `json:"caSecret,omitempty" protobuf:"bytes,11,opt,name=caSecret"`
+
+	// ParallelTransfers controls the maximum number of concurrent upload or download operations
+	ParallelTransfers *int32 `json:"parallelTransfers,omitempty" protobuf:"varint,13,opt,name=parallelTransfers"`
+
+	// MultipartPartSize controls the size of each part in multipart uploads in bytes
+	MultipartPartSize *int64 `json:"multipartPartSize,omitempty" protobuf:"varint,14,opt,name=multipartPartSize"`
+
+	// MultipartConcurrency controls the number of concurrent multipart upload parts
+	MultipartConcurrency *int32 `json:"multipartConcurrency,omitempty" protobuf:"varint,15,opt,name=multipartConcurrency"`
 }
 
 // S3EncryptionOptions used to determine encryption options during s3 operations

--- a/workflow/artifacts/artifacts.go
+++ b/workflow/artifacts/artifacts.go
@@ -104,6 +104,9 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 			KmsEncryptionContext:  kmsEncryptionContext,
 			EnableEncryption:      enableEncryption,
 			ServerSideCustomerKey: serverSideCustomerKey,
+			ParallelTransfers:     int(getOrDefaultInt32(art.S3.ParallelTransfers, 1)),
+			MultipartPartSize:     getOrDefaultInt64(art.S3.MultipartPartSize, 5*1024*1024),
+			MultipartConcurrency:  int(getOrDefaultInt32(art.S3.MultipartConcurrency, 4)),
 		}
 
 		return &driver, nil
@@ -275,4 +278,21 @@ func newDriver(ctx context.Context, art *wfv1.Artifact, ri resource.Interface) (
 	}
 
 	return nil, ErrUnsupportedDriver
+}
+
+func getOrDefaultInt32(val *int32, def int32) int32 {
+	if val != nil && *val > 0 {
+		if *val > 32 {
+			return 32
+		}
+		return *val
+	}
+	return def
+}
+
+func getOrDefaultInt64(val *int64, def int64) int64 {
+	if val != nil && *val > 0 {
+		return *val
+	}
+	return def
 }


### PR DESCRIPTION
## Summary
- add parallel transfer options to S3 bucket config
- honour new settings when creating the S3 driver
- support multipart concurrency in S3 transfers
- upload/download directories concurrently

## Testing
- `make pre-commit -B` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d69b9dc8c8327887491cf5e720ee0